### PR TITLE
Fix message truncation bug

### DIFF
--- a/lib/logstash/outputs/datadog_logs.rb
+++ b/lib/logstash/outputs/datadog_logs.rb
@@ -26,7 +26,7 @@ class LogStash::Outputs::DatadogLogs < LogStash::Outputs::Base
 
     client_socket = nil
     @codec.on_event do |event, payload|
-      # open a connection if needed and send JSON payload      
+      # open a connection if needed and send JSON payload
       begin
         client_socket = new_client_socket unless client_socket
         r,w,e = IO.select([client_socket], [client_socket], [client_socket], nil)
@@ -34,7 +34,7 @@ class LogStash::Outputs::DatadogLogs < LogStash::Outputs::Base
         if w.any?
           # send message to Datadog
           message = "#{@api_key} #{payload}\n"
-          client_socket.syswrite(message)
+          client_socket.puts(message)
           @logger.debug("Sent", :payload => payload)
         end # w.any?
       rescue => e
@@ -56,8 +56,8 @@ class LogStash::Outputs::DatadogLogs < LogStash::Outputs::Base
 
   private
   def new_client_socket
-    # open a secure connection with Datadog    
-    begin      
+    # open a secure connection with Datadog
+    begin
       socket = TCPSocket.new @host, @port
       sslSocket = OpenSSL::SSL::SSLSocket.new socket
       sslSocket.connect


### PR DESCRIPTION
### What does this PR do?

Fix the bug where messages would be truncated to 16k

### Motivation

https://github.com/DataDog/logstash-output-datadog_logs/issues/7

### Additional Notes

`syswrite` is the std lib function calls the `write` syscall with the data.
https://github.com/ruby/ruby/blob/v2_5_1/io.c#L4990 > https://github.com/ruby/ruby/blob/v2_5_1/io.c#L982 > 
https://github.com/ruby/ruby/blob/v2_5_1/io.c#L944

The SSL frame size if 16kB (or 32kB) so I suspect the ssl socket buffer size to be 16kB. That would explain the write call being truncated at 16kB

The SSL lib implements the `puts` method that loops over the data to be sent by multiple call to `syswrite` until the whole string has been sent: https://github.com/ruby/openssl/blob/v2.1.1/lib/openssl/buffering.rb#L416 > https://github.com/ruby/openssl/blob/v2.1.1/lib/openssl/buffering.rb#L322 