### PR TITLE
[0.4.1][Fix]: Manage manticore HTTP retryable exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.4.1
+  - Fix HTTP bug when remote server is timing out 
+
 ## 0.4.0
   - Enable HTTP forwarding for logs
   - Provide an option to disable SSL hostname verification for HTTPS

--- a/lib/logstash/outputs/datadog_logs.rb
+++ b/lib/logstash/outputs/datadog_logs.rb
@@ -61,7 +61,7 @@ class LogStash::Outputs::DatadogLogs < LogStash::Outputs::Base
           process_encoded_payload(format_tcp_event(encoded_event.last, @api_key, DD_MAX_BATCH_SIZE))
         end
       end
-    rescue Exception => e
+    rescue => e
       @logger.error("Uncaught processing exception in datadog forwarder #{e.message}")
     end
   end
@@ -168,7 +168,7 @@ class LogStash::Outputs::DatadogLogs < LogStash::Outputs::Base
           retries += 1
           retry
         end
-      rescue Exception => ex
+      rescue => ex
         @logger.error("Unmanaged exception while sending log to datadog #{ex.message}")
       end
     end
@@ -189,8 +189,7 @@ class LogStash::Outputs::DatadogLogs < LogStash::Outputs::Base
         ::Manticore::Timeout,
         ::Manticore::SocketException,
         ::Manticore::ClientProtocolException,
-        ::Manticore::ResolutionFailure,
-        ::Manticore::SocketTimeout
+        ::Manticore::ResolutionFailure
     ]
 
     def initialize(logger, use_ssl, no_ssl_validation, host, port, use_compression, api_key)

--- a/lib/logstash/outputs/datadog_logs.rb
+++ b/lib/logstash/outputs/datadog_logs.rb
@@ -50,15 +50,19 @@ class LogStash::Outputs::DatadogLogs < LogStash::Outputs::Base
   def multi_receive(events)
     return if events.empty?
     encoded_events = @codec.multi_encode(events)
-    if @use_http
-      batches = batch_http_events(encoded_events, DD_MAX_BATCH_LENGTH, DD_MAX_BATCH_SIZE)
-      batches.each do |batched_event|
-        process_encoded_payload(format_http_event_batch(batched_event))
+    begin
+      if @use_http
+        batches = batch_http_events(encoded_events, DD_MAX_BATCH_LENGTH, DD_MAX_BATCH_SIZE)
+        batches.each do |batched_event|
+          process_encoded_payload(format_http_event_batch(batched_event))
+        end
+      else
+        encoded_events.each do |encoded_event|
+          process_encoded_payload(format_tcp_event(encoded_event.last, @api_key, DD_MAX_BATCH_SIZE))
+        end
       end
-    else
-      encoded_events.each do |encoded_event|
-        process_encoded_payload(format_tcp_event(encoded_event.last, @api_key, DD_MAX_BATCH_SIZE))
-      end
+    rescue Exception => e
+      @logger.error("Uncaught processing exception in datadog forwarder #{e.message}")
     end
   end
 
@@ -158,12 +162,14 @@ class LogStash::Outputs::DatadogLogs < LogStash::Outputs::Base
         send(payload)
       rescue RetryableError => e
         if retries < max_retries || max_retries < 0
-          @logger.warn("Retrying ", :exception => e, :backtrace => e.backtrace)
+          @logger.warn("Retrying send due to: #{e.message}")
           sleep backoff
           backoff = 2 * backoff unless backoff > max_backoff
           retries += 1
           retry
         end
+      rescue Exception => ex
+        @logger.error("Unmanaged exception while sending log to datadog #{ex.message}")
       end
     end
 
@@ -178,6 +184,14 @@ class LogStash::Outputs::DatadogLogs < LogStash::Outputs::Base
 
   class DatadogHTTPClient < DatadogClient
     require "manticore"
+
+    RETRYABLE_EXCEPTIONS = [
+        ::Manticore::Timeout,
+        ::Manticore::SocketException,
+        ::Manticore::ClientProtocolException,
+        ::Manticore::ResolutionFailure,
+        ::Manticore::SocketTimeout
+    ]
 
     def initialize(logger, use_ssl, no_ssl_validation, host, port, use_compression, api_key)
       @logger = logger
@@ -194,13 +208,27 @@ class LogStash::Outputs::DatadogLogs < LogStash::Outputs::Base
     end
 
     def send(payload)
-      response = @client.post(@url, :body => payload, :headers => @headers).call
-      if response.code >= 500
-        raise RetryableError.new "Unable to send payload: #{response.code} #{response.body}"
+      begin
+        response = @client.post(@url, :body => payload, :headers => @headers).call
+        if response.code >= 500
+          raise RetryableError.new "Unable to send payload: #{response.code} #{response.body}"
+        end
+        if response.code >= 400
+          @logger.error("Unable to send payload due to client error: #{response.code} #{response.body}")
+        end
+      rescue => client_exception
+        should_retry = retryable_exception?(client_exception)
+        if should_retry
+          raise RetryableError.new "Unable to send payload #{client_exception.message}"
+        else
+          raise client_exception
+        end
       end
-      if response.code >= 400
-        @logger.error("Unable to send payload due to client error: #{response.code} #{response.body}")
-      end
+
+    end
+
+    def retryable_exception?(exception)
+      RETRYABLE_EXCEPTIONS.any? { |e| exception.is_a?(e) }
     end
 
     def close

--- a/logstash-output-datadog_logs.gemspec
+++ b/logstash-output-datadog_logs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-output-datadog_logs'
-  s.version       = '0.4.0'
+  s.version       = '0.4.1'
   s.licenses      = ['Apache-2.0']
   s.summary       = 'DatadogLogs lets you send logs to Datadog based on LogStash events.'
   s.homepage      = 'https://www.datadoghq.com/'
@@ -22,4 +22,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash-codec-json'
 
   s.add_development_dependency 'logstash-devutils'
+  s.add_development_dependency 'webmock'
 end


### PR DESCRIPTION
### What does this PR do?

Manage manticore retryable exceptions for HTTP to prevent stopping the forwarder.

### Motivation
In case of socket timeout, the forwarder was stopping. Instead catch it and catch any unknown exception to keep the forwarder/logstash running.

### Additional Notes

Anything else we should know when reviewing?
