### PR TITLE
Add error log when max # of retries reached

### DIFF
--- a/lib/logstash/outputs/datadog_logs.rb
+++ b/lib/logstash/outputs/datadog_logs.rb
@@ -168,6 +168,7 @@ class LogStash::Outputs::DatadogLogs < LogStash::Outputs::Base
           retries += 1
           retry
         end
+        @logger.error("Max number of retries reached, dropping message. Last exception: #{ex.message}")
       rescue => ex
         @logger.error("Unmanaged exception while sending log to datadog #{ex.message}")
       end


### PR DESCRIPTION
### What does this PR do?

This adds an error log when the max number of retries when sending is reached, which means that some messages are dropped.

### Motivation

The default configuration is lossy - 5 number of retries and some messages are lost. This should only very rarely affect transient errors, however the max retries can easily be reached when the output is misconfigured (wrong API key, wrong HTTP/TCP config).

In all cases, it is important to be able to determine how often the max retries was reached, meaning messages are lost, which is currently not possible with the logging available.
