### PR TITLE
Add support for v2 routes.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
             sudo apt-get update && sudo apt-get install logstash
       - run:
           name: Install Plugin
-          command: sudo /usr/share/logstash/bin/logstash-plugin install logstash-output-datadog_logs-${VERSION}.gem
+          command: sudo /usr/share/logstash/bin/logstash-plugin install logstash-output-datadog_logs-$(cat lib/logstash/outputs/version.rb| grep VERSION| cut -d"'" -f2).gem
       - run:
           name: Run Logstash
           shell: /bin/sh
@@ -55,7 +55,7 @@ jobs:
             sudo apt-get update && sudo apt-get install logstash
       - run:
           name: Install Plugin
-          command: sudo /usr/share/logstash/bin/logstash-plugin install logstash-output-datadog_logs-${VERSION}.gem
+          command: sudo /usr/share/logstash/bin/logstash-plugin install logstash-output-datadog_logs-$(cat lib/logstash/outputs/version.rb| grep VERSION| cut -d"'" -f2).gem
       - run:
           name: Run Logstash
           shell: /bin/sh
@@ -85,7 +85,7 @@ jobs:
             sudo apt-get update && sudo apt-get install logstash
       - run:
           name: Install Plugin
-          command: sudo /usr/share/logstash/bin/logstash-plugin install logstash-output-datadog_logs-${VERSION}.gem
+          command: sudo /usr/share/logstash/bin/logstash-plugin install logstash-output-datadog_logs-$(cat lib/logstash/outputs/version.rb| grep VERSION| cut -d"'" -f2).gem
       - run:
           name: Run Logstash
           shell: /bin/sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ jobs:
 
   test:
     docker:
-      - image: circleci/jruby:latest
+      - image: circleci/jruby:9.2.11.1-jre8-node-browsers
 
     steps:
       - checkout

--- a/lib/logstash/outputs/datadog_logs.rb
+++ b/lib/logstash/outputs/datadog_logs.rb
@@ -222,6 +222,7 @@ class LogStash::Outputs::DatadogLogs < LogStash::Outputs::Base
     def send(payload)
       begin
         response = @client.post(@url, :body => payload, :headers => @headers).call
+        # in case of error or 429, we will retry sending this payload
         if response.code >= 500 || response.code == 429
           raise RetryableError.new "Unable to send payload: #{response.code} #{response.body}"
         end

--- a/lib/logstash/outputs/version.rb
+++ b/lib/logstash/outputs/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module DatadogLogStashPlugin
+  VERSION = '0.4.2'
+end

--- a/logstash-output-datadog_logs.gemspec
+++ b/logstash-output-datadog_logs.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'manticore', '>= 0.5.2', '< 1.0.0'
   s.add_runtime_dependency 'logstash-codec-json'
 
-  s.add_development_dependency 'logstash-devutils'
+  s.add_development_dependency 'logstash-devutils', "= 1.3.6"
   s.add_development_dependency 'webmock'
 end

--- a/logstash-output-datadog_logs.gemspec
+++ b/logstash-output-datadog_logs.gemspec
@@ -1,6 +1,12 @@
+# Load version.rb containing the DatadogLogStashPlugin::VERSION
+# for current Gem version.
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require "logstash/outputs/version.rb"
+
 Gem::Specification.new do |s|
   s.name          = 'logstash-output-datadog_logs'
-  s.version       = '0.4.1'
+  s.version       = DatadogLogStashPlugin::VERSION
   s.licenses      = ['Apache-2.0']
   s.summary       = 'DatadogLogs lets you send logs to Datadog based on LogStash events.'
   s.homepage      = 'https://www.datadoghq.com/'

--- a/spec/outputs/datadog_logs_spec.rb
+++ b/spec/outputs/datadog_logs_spec.rb
@@ -90,10 +90,10 @@ describe LogStash::Outputs::DatadogLogs do
   end
 
   context "when facing HTTP connection issues" do
-    ['true', 'false'].each do |force_v1_routes|
-        it "should retry when server is returning 5XX" do
+    [true, false].each do |force_v1_routes|
+        it "should retry when server is returning 5XX " + (force_v1_routes ? "using v1 routes" : "using v2 routes") do
           api_key = 'XXX'
-          stub_dd_request_with_return_code(api_key, 500)
+          stub_dd_request_with_return_code(api_key, 500, force_v1_routes)
           payload = '{}'
           client = LogStash::Outputs::DatadogLogs::DatadogHTTPClient.new Logger.new(STDOUT), false, false, "datadog.com", 80, false, api_key, force_v1_routes
           expect { client.send(payload) }.to raise_error(LogStash::Outputs::DatadogLogs::RetryableError)
@@ -101,7 +101,7 @@ describe LogStash::Outputs::DatadogLogs do
 
         it "should not retry when server is returning 4XX" do
           api_key = 'XXX'
-          stub_dd_request_with_return_code(api_key, 400)
+          stub_dd_request_with_return_code(api_key, 400, force_v1_routes)
           payload = '{}'
           client = LogStash::Outputs::DatadogLogs::DatadogHTTPClient.new Logger.new(STDOUT), false, false, "datadog.com", 80, false, api_key, force_v1_routes
           expect { client.send(payload) }.to_not raise_error
@@ -109,7 +109,7 @@ describe LogStash::Outputs::DatadogLogs do
 
         it "should retry when server is returning 429" do
           api_key = 'XXX'
-          stub_dd_request_with_return_code(api_key, 429)
+          stub_dd_request_with_return_code(api_key, 429, force_v1_routes)
           payload = '{}'
           client = LogStash::Outputs::DatadogLogs::DatadogHTTPClient.new Logger.new(STDOUT), false, false, "datadog.com", 80, false, api_key, force_v1_routes
           expect { client.send(payload) }.to raise_error(LogStash::Outputs::DatadogLogs::RetryableError)
@@ -117,7 +117,7 @@ describe LogStash::Outputs::DatadogLogs do
 
         it "should retry when facing a timeout exception from manticore" do
           api_key = 'XXX'
-          stub_dd_request_with_error(api_key, Manticore::Timeout)
+          stub_dd_request_with_error(api_key, Manticore::Timeout, force_v1_routes)
           payload = '{}'
           client = LogStash::Outputs::DatadogLogs::DatadogHTTPClient.new Logger.new(STDOUT), false, false, "datadog.com", 80, false, api_key, force_v1_routes
           expect { client.send(payload) }.to raise_error(LogStash::Outputs::DatadogLogs::RetryableError)
@@ -125,7 +125,7 @@ describe LogStash::Outputs::DatadogLogs do
 
         it "should retry when facing a socket exception from manticore" do
           api_key = 'XXX'
-          stub_dd_request_with_error(api_key, Manticore::SocketException)
+          stub_dd_request_with_error(api_key, Manticore::SocketException, force_v1_routes)
           payload = '{}'
           client = LogStash::Outputs::DatadogLogs::DatadogHTTPClient.new Logger.new(STDOUT), false, false, "datadog.com", 80, false, api_key, force_v1_routes
           expect { client.send(payload) }.to raise_error(LogStash::Outputs::DatadogLogs::RetryableError)
@@ -133,7 +133,7 @@ describe LogStash::Outputs::DatadogLogs do
 
         it "should retry when facing a client protocol exception from manticore" do
           api_key = 'XXX'
-          stub_dd_request_with_error(api_key, Manticore::ClientProtocolException)
+          stub_dd_request_with_error(api_key, Manticore::ClientProtocolException, force_v1_routes)
           payload = '{}'
           client = LogStash::Outputs::DatadogLogs::DatadogHTTPClient.new Logger.new(STDOUT), false, false, "datadog.com", 80, false, api_key, force_v1_routes
           expect { client.send(payload) }.to raise_error(LogStash::Outputs::DatadogLogs::RetryableError)
@@ -141,7 +141,7 @@ describe LogStash::Outputs::DatadogLogs do
 
         it "should retry when facing a dns failure from manticore" do
           api_key = 'XXX'
-          stub_dd_request_with_error(api_key, Manticore::ResolutionFailure)
+          stub_dd_request_with_error(api_key, Manticore::ResolutionFailure, force_v1_routes)
           payload = '{}'
           client = LogStash::Outputs::DatadogLogs::DatadogHTTPClient.new Logger.new(STDOUT), false, false, "datadog.com", 80, false, api_key, force_v1_routes
           expect { client.send(payload) }.to raise_error(LogStash::Outputs::DatadogLogs::RetryableError)
@@ -149,7 +149,7 @@ describe LogStash::Outputs::DatadogLogs do
 
         it "should retry when facing a socket timeout from manticore" do
           api_key = 'XXX'
-          stub_dd_request_with_error(api_key, Manticore::SocketTimeout)
+          stub_dd_request_with_error(api_key, Manticore::SocketTimeout, force_v1_routes)
           payload = '{}'
           client = LogStash::Outputs::DatadogLogs::DatadogHTTPClient.new Logger.new(STDOUT), false, false, "datadog.com", 80, false, api_key, force_v1_routes
           expect { client.send(payload) }.to raise_error(LogStash::Outputs::DatadogLogs::RetryableError)
@@ -157,7 +157,7 @@ describe LogStash::Outputs::DatadogLogs do
 
         it "should not retry when facing any other general error" do
           api_key = 'XXX'
-          stub_dd_request_with_error(api_key, StandardError)
+          stub_dd_request_with_error(api_key, StandardError, force_v1_routes)
           payload = '{}'
           client = LogStash::Outputs::DatadogLogs::DatadogHTTPClient.new Logger.new(STDOUT), false, false, "datadog.com", 80, false, api_key, force_v1_routes
           expect { client.send(payload) }.to raise_error(StandardError)
@@ -165,7 +165,7 @@ describe LogStash::Outputs::DatadogLogs do
 
         it "should not stop the forwarder when facing any client uncaught exception" do
           api_key = 'XXX'
-          stub_dd_request_with_error(api_key, StandardError)
+          stub_dd_request_with_error(api_key, StandardError, force_v1_routes)
           payload = '{}'
           client = LogStash::Outputs::DatadogLogs::DatadogHTTPClient.new Logger.new(STDOUT), false, false, "datadog.com", 80, false, api_key, force_v1_routes
           expect { client.send_retries(payload, 2, 2) }.to_not raise_error
@@ -187,24 +187,36 @@ describe LogStash::Outputs::DatadogLogs do
     end
   end
 
-  def stub_dd_request_with_return_code(api_key, return_code)
-    stub_dd_request(api_key).
+  def stub_dd_request_with_return_code(api_key, return_code, force_v1_routes)
+    stub_dd_request(api_key, force_v1_routes).
         to_return(status: return_code, body: "", headers: {})
   end
 
-  def stub_dd_request_with_error(api_key, error)
-    stub_dd_request(api_key).
+  def stub_dd_request_with_error(api_key, error, force_v1_routes)
+    stub_dd_request(api_key, force_v1_routes).
         to_raise(error)
   end
 
-  def stub_dd_request(api_key)
-    stub_request(:post, "http://datadog.com/v1/input/#{api_key}").
+  def stub_dd_request(api_key, force_v1_routes)
+    if force_v1_routes
+      stub_request(:post, "http://datadog.com/v1/input/#{api_key}").
         with(
-            body: "{}",
-            headers: {
-                'Connection' => 'Keep-Alive',
-                'Content-Type' => 'application/json'
-            })
+          body: "{}",
+          headers: {
+            'Connection' => 'Keep-Alive',
+            'Content-Type' => 'application/json'
+        })
+    else
+      stub_request(:post, "http://datadog.com/api/v2/logs").
+        with(
+          body: "{}",
+          headers: {
+            'Connection' => 'Keep-Alive',
+            'Content-Type' => 'application/json',
+            'DD-API-KEY' => "#{api_key}",
+            'DD-EVP-ORIGIN' => 'logstash',
+            'DD-EVP-ORIGIN-VERSION' => DatadogLogStashPlugin::VERSION
+       })
+    end
   end
-
 end

--- a/spec/outputs/datadog_logs_spec.rb
+++ b/spec/outputs/datadog_logs_spec.rb
@@ -90,76 +90,86 @@ describe LogStash::Outputs::DatadogLogs do
   end
 
   context "when facing HTTP connection issues" do
-    it "should retry when server is returning 5XX" do
-      api_key = 'XXX'
-      stub_dd_request_with_return_code(api_key, 500)
-      payload = '{}'
-      client = LogStash::Outputs::DatadogLogs::DatadogHTTPClient.new Logger.new(STDOUT), false, false, "datadog.com", 80, false, api_key
-      expect { client.send(payload) }.to raise_error(LogStash::Outputs::DatadogLogs::RetryableError)
-    end
+    ['true', 'false'].each do |force_v1_routes|
+        it "should retry when server is returning 5XX" do
+          api_key = 'XXX'
+          stub_dd_request_with_return_code(api_key, 500)
+          payload = '{}'
+          client = LogStash::Outputs::DatadogLogs::DatadogHTTPClient.new Logger.new(STDOUT), false, false, "datadog.com", 80, false, api_key, force_v1_routes
+          expect { client.send(payload) }.to raise_error(LogStash::Outputs::DatadogLogs::RetryableError)
+        end
 
-    it "should not retry when server is returning 4XX" do
-      api_key = 'XXX'
-      stub_dd_request_with_return_code(api_key, 400)
-      payload = '{}'
-      client = LogStash::Outputs::DatadogLogs::DatadogHTTPClient.new Logger.new(STDOUT), false, false, "datadog.com", 80, false, api_key
-      expect { client.send(payload) }.to_not raise_error
-    end
+        it "should not retry when server is returning 4XX" do
+          api_key = 'XXX'
+          stub_dd_request_with_return_code(api_key, 400)
+          payload = '{}'
+          client = LogStash::Outputs::DatadogLogs::DatadogHTTPClient.new Logger.new(STDOUT), false, false, "datadog.com", 80, false, api_key, force_v1_routes
+          expect { client.send(payload) }.to_not raise_error
+        end
 
-    it "should retry when facing a timeout exception from manticore" do
-      api_key = 'XXX'
-      stub_dd_request_with_error(api_key, Manticore::Timeout)
-      payload = '{}'
-      client = LogStash::Outputs::DatadogLogs::DatadogHTTPClient.new Logger.new(STDOUT), false, false, "datadog.com", 80, false, api_key
-      expect { client.send(payload) }.to raise_error(LogStash::Outputs::DatadogLogs::RetryableError)
-    end
+        it "should retry when server is returning 429" do
+          api_key = 'XXX'
+          stub_dd_request_with_return_code(api_key, 429)
+          payload = '{}'
+          client = LogStash::Outputs::DatadogLogs::DatadogHTTPClient.new Logger.new(STDOUT), false, false, "datadog.com", 80, false, api_key, force_v1_routes
+          expect { client.send(payload) }.to raise_error(LogStash::Outputs::DatadogLogs::RetryableError)
+        end
 
-    it "should retry when facing a socket exception from manticore" do
-      api_key = 'XXX'
-      stub_dd_request_with_error(api_key, Manticore::SocketException)
-      payload = '{}'
-      client = LogStash::Outputs::DatadogLogs::DatadogHTTPClient.new Logger.new(STDOUT), false, false, "datadog.com", 80, false, api_key
-      expect { client.send(payload) }.to raise_error(LogStash::Outputs::DatadogLogs::RetryableError)
-    end
+        it "should retry when facing a timeout exception from manticore" do
+          api_key = 'XXX'
+          stub_dd_request_with_error(api_key, Manticore::Timeout)
+          payload = '{}'
+          client = LogStash::Outputs::DatadogLogs::DatadogHTTPClient.new Logger.new(STDOUT), false, false, "datadog.com", 80, false, api_key, force_v1_routes
+          expect { client.send(payload) }.to raise_error(LogStash::Outputs::DatadogLogs::RetryableError)
+        end
 
-    it "should retry when facing a client protocol exception from manticore" do
-      api_key = 'XXX'
-      stub_dd_request_with_error(api_key, Manticore::ClientProtocolException)
-      payload = '{}'
-      client = LogStash::Outputs::DatadogLogs::DatadogHTTPClient.new Logger.new(STDOUT), false, false, "datadog.com", 80, false, api_key
-      expect { client.send(payload) }.to raise_error(LogStash::Outputs::DatadogLogs::RetryableError)
-    end
+        it "should retry when facing a socket exception from manticore" do
+          api_key = 'XXX'
+          stub_dd_request_with_error(api_key, Manticore::SocketException)
+          payload = '{}'
+          client = LogStash::Outputs::DatadogLogs::DatadogHTTPClient.new Logger.new(STDOUT), false, false, "datadog.com", 80, false, api_key, force_v1_routes
+          expect { client.send(payload) }.to raise_error(LogStash::Outputs::DatadogLogs::RetryableError)
+        end
 
-    it "should retry when facing a dns failure from manticore" do
-      api_key = 'XXX'
-      stub_dd_request_with_error(api_key, Manticore::ResolutionFailure)
-      payload = '{}'
-      client = LogStash::Outputs::DatadogLogs::DatadogHTTPClient.new Logger.new(STDOUT), false, false, "datadog.com", 80, false, api_key
-      expect { client.send(payload) }.to raise_error(LogStash::Outputs::DatadogLogs::RetryableError)
-    end
+        it "should retry when facing a client protocol exception from manticore" do
+          api_key = 'XXX'
+          stub_dd_request_with_error(api_key, Manticore::ClientProtocolException)
+          payload = '{}'
+          client = LogStash::Outputs::DatadogLogs::DatadogHTTPClient.new Logger.new(STDOUT), false, false, "datadog.com", 80, false, api_key, force_v1_routes
+          expect { client.send(payload) }.to raise_error(LogStash::Outputs::DatadogLogs::RetryableError)
+        end
 
-    it "should retry when facing a socket timeout from manticore" do
-      api_key = 'XXX'
-      stub_dd_request_with_error(api_key, Manticore::SocketTimeout)
-      payload = '{}'
-      client = LogStash::Outputs::DatadogLogs::DatadogHTTPClient.new Logger.new(STDOUT), false, false, "datadog.com", 80, false, api_key
-      expect { client.send(payload) }.to raise_error(LogStash::Outputs::DatadogLogs::RetryableError)
-    end
+        it "should retry when facing a dns failure from manticore" do
+          api_key = 'XXX'
+          stub_dd_request_with_error(api_key, Manticore::ResolutionFailure)
+          payload = '{}'
+          client = LogStash::Outputs::DatadogLogs::DatadogHTTPClient.new Logger.new(STDOUT), false, false, "datadog.com", 80, false, api_key, force_v1_routes
+          expect { client.send(payload) }.to raise_error(LogStash::Outputs::DatadogLogs::RetryableError)
+        end
 
-    it "should not retry when facing any other general error" do
-      api_key = 'XXX'
-      stub_dd_request_with_error(api_key, StandardError)
-      payload = '{}'
-      client = LogStash::Outputs::DatadogLogs::DatadogHTTPClient.new Logger.new(STDOUT), false, false, "datadog.com", 80, false, api_key
-      expect { client.send(payload) }.to raise_error(StandardError)
-    end
+        it "should retry when facing a socket timeout from manticore" do
+          api_key = 'XXX'
+          stub_dd_request_with_error(api_key, Manticore::SocketTimeout)
+          payload = '{}'
+          client = LogStash::Outputs::DatadogLogs::DatadogHTTPClient.new Logger.new(STDOUT), false, false, "datadog.com", 80, false, api_key, force_v1_routes
+          expect { client.send(payload) }.to raise_error(LogStash::Outputs::DatadogLogs::RetryableError)
+        end
 
-    it "should not stop the forwarder when facing any client uncaught exception" do
-      api_key = 'XXX'
-      stub_dd_request_with_error(api_key, StandardError)
-      payload = '{}'
-      client = LogStash::Outputs::DatadogLogs::DatadogHTTPClient.new Logger.new(STDOUT), false, false, "datadog.com", 80, false, api_key
-      expect { client.send_retries(payload, 2, 2) }.to_not raise_error
+        it "should not retry when facing any other general error" do
+          api_key = 'XXX'
+          stub_dd_request_with_error(api_key, StandardError)
+          payload = '{}'
+          client = LogStash::Outputs::DatadogLogs::DatadogHTTPClient.new Logger.new(STDOUT), false, false, "datadog.com", 80, false, api_key, force_v1_routes
+          expect { client.send(payload) }.to raise_error(StandardError)
+        end
+
+        it "should not stop the forwarder when facing any client uncaught exception" do
+          api_key = 'XXX'
+          stub_dd_request_with_error(api_key, StandardError)
+          payload = '{}'
+          client = LogStash::Outputs::DatadogLogs::DatadogHTTPClient.new Logger.new(STDOUT), false, false, "datadog.com", 80, false, api_key, force_v1_routes
+          expect { client.send_retries(payload, 2, 2) }.to_not raise_error
+        end
     end
   end
 


### PR DESCRIPTION
Add support for v2 routes to send logs to Datadog intake.

  * Previous behavior can be restored using the configuration field `force_v1_routes`.
  * Introduction of `version.rb` to automatically set the Gem version in the HTTP headers.
  * Fix the CI pinning JRuby version used (more recent versions of logstash-devutils used for the CI don't work with `circleci/jruby:latest` for some reasons)
  * Adapt unit tests to go through both branches (with and without using v2 routes) + unit test for HTTP `429`

Can be read commit per commit if needed.