### PR TITLE
Add proxy functionality and fix no_ssl_validation bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ output {
 |  Property   |  Description                                                             |  Default value |
 |-------------|--------------------------------------------------------------------------|----------------|
 | **api_key** | The API key of your Datadog platform | nil |
-| **host** | Proxy endpoint when logs are not directly forwarded to Datadog | intake.logs.datadoghq.com |
-| **port** | Proxy port when logs are not directly forwarded to Datadog | 443 |
+| **host** | Endpoint when logs are not directly forwarded to Datadog | intake.logs.datadoghq.com |
+| **port** | Port when logs are not directly forwarded to Datadog | 443 |
 | **use_ssl** | If true, the agent initializes a secure connection to Datadog. Ensure to update the port if you disable it. | true |
 | **max_retries** | The number of retries before the output plugin stops | 5 |
 | **max_backoff** | The maximum time waited between each retry in seconds | 30 |
@@ -67,6 +67,7 @@ output {
 | **use_compression** | Enable log compression for HTTP | true |
 | **compression_level** | Set the log compression level for HTTP (1 to 9, 9 being the best ratio) | 6 |
 | **no_ssl_validation** | Disable SSL validation (useful for proxy forwarding) | false |
+| **http_proxy** | Proxy address for http proxies | none |
 
 
 

--- a/lib/logstash/outputs/datadog_logs.rb
+++ b/lib/logstash/outputs/datadog_logs.rb
@@ -216,8 +216,7 @@ class LogStash::Outputs::DatadogLogs < LogStash::Outputs::Base
       logger.info("Starting HTTP connection to #{protocol}://#{host}:#{port.to_s} with compression " + (use_compression ? "enabled" : "disabled") + (force_v1_routes ? " using v1 routes" : " using v2 routes"))
 
       config = {}
-      config[:ssl] = {}
-      config[:verify] = :disable if no_ssl_validation
+      config[:ssl][:verify] = :disable if no_ssl_validation
       if http_proxy != ""
         config[:proxy] = http_proxy
       end


### PR DESCRIPTION
### What does this PR do?

This PR enables the passing of an HTTP proxy address to be used by Manticore.
In addition it removes a bug when trying to use `no_ssl_validation`.

### Motivation

We are using this plugin and any machine which is behind a proxy can't send its logs to Datadog.

