### PR TITLE
add links to GitHub from gem metadata

### DIFF
--- a/logstash-output-datadog_logs.gemspec
+++ b/logstash-output-datadog_logs.gemspec
@@ -19,8 +19,16 @@ Gem::Specification.new do |s|
   # Tests
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
 
-  # Special flag to let us know this is actually a logstash plugin
-  s.metadata = {"logstash_plugin" => "true", "logstash_group" => "output"}
+  s.metadata = {
+    'bug_tracker_uri'   => 'https://github.com/DataDog/logstash-output-datadog_logs/issues',
+    'changelog_uri'     => 'https://github.com/DataDog/logstash-output-datadog_logs/blob/master/CHANGELOG.md',
+    'documentation_uri' => 'https://github.com/DataDog/logstash-output-datadog_logs/blob/master/README.md',
+    'source_code_uri'   => 'https://github.com/DataDog/logstash-output-datadog_logs',
+
+    # Special flag to let us know this is actually a logstash plugin
+    "logstash_plugin" => "true",
+    "logstash_group" => "output",
+  }
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", "~> 2.0"


### PR DESCRIPTION
### What does this PR do?

Adds links to GitHub in gem metadata.

### Motivation

Make it easier to find the source code from RubyGems.

### Additional Notes

This is a small PR but I know nothing about Ruby so please make sure I didn't break anything.

Coded added has been copied from https://github.com/DataDog/dogapi-rb/blob/656e3260c01adac92f998f9f58993291efdc8a8b/dogapi.gemspec#L16 and adapted.