### PR TITLE
Prepare release 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.5.1
+  - Support using HTTP proxies, adding the `http_proxy` parameter.
+
 ## 0.5.0
   - Support Datadog v2 endpoints #28
 

--- a/lib/logstash/outputs/version.rb
+++ b/lib/logstash/outputs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DatadogLogStashPlugin
-  VERSION = '0.5.0'
+  VERSION = '0.5.1'
 end


### PR DESCRIPTION
### What does this PR do?

Prepare release 0.5.1 adding support for the `http_proxy` parameter.
