### PR TITLE
The plugin now supports interruption.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.5.2
+  - Now checks if logstash is being shutdown
+
 ## 0.5.1
   - Support using HTTP proxies, adding the `http_proxy` parameter.
 

--- a/lib/logstash/outputs/datadog_logs.rb
+++ b/lib/logstash/outputs/datadog_logs.rb
@@ -178,7 +178,7 @@ class LogStash::Outputs::DatadogLogs < LogStash::Outputs::Base
           retries += 1
           retry
         end
-        @logger.error("Max number of retries reached, dropping message. Last exception: #{ex.message}")
+        @logger.error("Max number of retries reached, dropping message. Last exception: #{e.message}")
       rescue => ex
         if ex.is_a?(InterruptedError)
           raise ex

--- a/lib/logstash/outputs/datadog_logs.rb
+++ b/lib/logstash/outputs/datadog_logs.rb
@@ -65,7 +65,11 @@ class LogStash::Outputs::DatadogLogs < LogStash::Outputs::Base
         end
       end
     rescue => e
-      @logger.error("Uncaught processing exception in datadog forwarder #{e.message}")
+      if e.is_a?(InterruptedError)
+        raise e
+      else
+        @logger.error("Uncaught processing exception in datadog forwarder #{e.message}")
+      end
     end
   end
 
@@ -148,7 +152,7 @@ class LogStash::Outputs::DatadogLogs < LogStash::Outputs::Base
   # Build a new transport client
   def new_client(logger, api_key, use_http, use_ssl, no_ssl_validation, host, port, use_compression, force_v1_routes, http_proxy)
     if use_http
-      DatadogHTTPClient.new logger, use_ssl, no_ssl_validation, host, port, use_compression, api_key, force_v1_routes, http_proxy
+      DatadogHTTPClient.new logger, use_ssl, no_ssl_validation, host, port, use_compression, api_key, force_v1_routes, http_proxy, -> { defined?(pipeline_shutdown_requested?) ? pipeline_shutdown_requested? : false }
     else
       DatadogTCPClient.new logger, use_ssl, no_ssl_validation, host, port
     end

--- a/lib/logstash/outputs/datadog_logs.rb
+++ b/lib/logstash/outputs/datadog_logs.rb
@@ -218,7 +218,8 @@ class LogStash::Outputs::DatadogLogs < LogStash::Outputs::Base
         ::Manticore::ResolutionFailure
     ]
 
-    def initialize(logger, use_ssl, no_ssl_validation, host, port, use_compression, api_key, force_v1_routes, http_proxy)
+    def initialize(logger, use_ssl, no_ssl_validation, host, port, use_compression, api_key, force_v1_routes, http_proxy, interruptedLambda = nil)
+      @interruptedLambda = interruptedLambda
       @logger = logger
       protocol = use_ssl ? "https" : "http"
 
@@ -244,6 +245,14 @@ class LogStash::Outputs::DatadogLogs < LogStash::Outputs::Base
         config[:proxy] = http_proxy
       end
       @client = Manticore::Client.new(config)
+    end
+
+    def interrupted?
+      if @interruptedLambda
+        return @interruptedLambda.call
+      end
+
+      false
     end
 
     def send(payload)

--- a/lib/logstash/outputs/version.rb
+++ b/lib/logstash/outputs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DatadogLogStashPlugin
-  VERSION = '0.5.1'
+  VERSION = '0.5.2'
 end


### PR DESCRIPTION
### What does this PR do?
It attempts to fix https://github.com/DataDog/logstash-output-datadog_logs/issues/42

The DataDog plugin has been enhanced to leverage Logstash Output Plugin APIs. Specifically, the **pipeline_shutdown_requested?** method from parent class **LogStash::Outputs::Base**.


### Motivation

Configuring Logstash's Persistent Queues (https://www.elastic.co/guide/en/logstash/current/persistent-queues.html) wouldn't work properly in all scenarios (e.g. gracefully restarting Logstash) involving DataDog Logstash Output Plugin.

### Additional Notes

These changes are mostly inspired by the [Logstash Http Output Plugin](https://github.com/logstash-plugins/logstash-output-http/blob/e046333fdad350c06c1d6a8127dbd024413fa03d/lib/logstash/outputs/http.rb#L184). Logstash's Persistent Queues work as intended when using this output plugin.