### PR TITLE
The plugin's shared concurrency flag has been set.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.5.3
+  - Now is threadsafe: supports shared concurrency.
+
 ## 0.5.2
   - Now checks if logstash is being shutdown
 

--- a/lib/logstash/outputs/datadog_logs.rb
+++ b/lib/logstash/outputs/datadog_logs.rb
@@ -21,6 +21,8 @@ class LogStash::Outputs::DatadogLogs < LogStash::Outputs::Base
 
   config_name "datadog_logs"
 
+  concurrency :shared
+
   default :codec, "json"
 
   # Datadog configuration parameters

--- a/lib/logstash/outputs/datadog_logs.rb
+++ b/lib/logstash/outputs/datadog_logs.rb
@@ -298,6 +298,7 @@ class LogStash::Outputs::DatadogLogs < LogStash::Outputs::Base
       @no_ssl_validation = no_ssl_validation
       @host = host
       @port = port
+      @send_mutex = Mutex.new
     end
 
     def connect
@@ -318,13 +319,15 @@ class LogStash::Outputs::DatadogLogs < LogStash::Outputs::Base
     end
 
     def send(payload)
-      begin
-        @socket ||= connect
-        @socket.puts(payload)
-      rescue => e
-        @socket.close rescue nil
-        @socket = nil
-        raise RetryableError.new "Unable to send payload: #{e.message}."
+      @send_mutex.synchronize do
+        begin
+          @socket ||= connect
+          @socket.puts(payload)
+        rescue => e
+          @socket.close rescue nil
+          @socket = nil
+          raise RetryableError.new "Unable to send payload: #{e.message}."
+        end
       end
     end
 

--- a/lib/logstash/outputs/version.rb
+++ b/lib/logstash/outputs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DatadogLogStashPlugin
-  VERSION = '0.5.2'
+  VERSION = '0.5.3'
 end


### PR DESCRIPTION
### What does this PR do?

It attempts to fix #26

The DataDog plugin has been updated to be thread-safe and the plugin has been flagged as so.

Specifically:

- The **send** method of the **DatadogTCPClient** class has been synchronized. It is effectively single-threaded.
- The **send** method of the **DatadogHTTPClient** class was already thread-safe.
- The **concurrency :shared** flag has been set.

### Motivation

We were having concurrency issues as per #26

### Additional Notes

We were unable to test the **DatadogTCPClient**. We tried to configure the plugin as per the README.md but were unable to send a log even before these changes.
