### PR TITLE
fix: increase DD_MAX_BATCH_LENGTH to 1000

### DIFF
--- a/lib/logstash/outputs/datadog_logs.rb
+++ b/lib/logstash/outputs/datadog_logs.rb
@@ -14,8 +14,8 @@ require_relative "version"
 # based on LogStash events.
 class LogStash::Outputs::DatadogLogs < LogStash::Outputs::Base
 
-  # Respect limit documented at https://docs.datadoghq.com/api/?lang=bash#logs
-  DD_MAX_BATCH_LENGTH = 500
+  # Respect limit documented at https://docs.datadoghq.com/api/latest/logs/#send-logs
+  DD_MAX_BATCH_LENGTH = 1000
   DD_MAX_BATCH_SIZE = 5000000
   DD_TRUNCATION_SUFFIX = "...TRUNCATED..."
 


### PR DESCRIPTION
### What does this PR do?

Increases the hardcoded `DD_MAX_BATCH_LENGTH` from 500 to 1000.

### Motivation

The API docs defines a maximum array size of 1000 entries: https://docs.datadoghq.com/api/latest/logs/#send-logs

This will help us increase our log processing throughput without requiring more nodes.

### Additional Notes

Anything else we should know when reviewing?
