### PR TITLE
chore(docs): update README to correct endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To enable TCP forwarding, configure your forwarder with:
 output {
     datadog_logs {
         api_key => "<DATADOG_API_KEY>"
-        host => "intake.logs.datadoghq.com"
+        host => "http-intake.logs.datadoghq.com"
         port => 443
         use_http => false
     }
@@ -58,7 +58,7 @@ output {
 |  Property   |  Description                                                             |  Default value |
 |-------------|--------------------------------------------------------------------------|----------------|
 | **api_key** | The API key of your Datadog platform | nil |
-| **host** | Endpoint when logs are not directly forwarded to Datadog | intake.logs.datadoghq.com |
+| **host** | Endpoint when logs are not directly forwarded to Datadog | http-intake.logs.datadoghq.com |
 | **port** | Port when logs are not directly forwarded to Datadog | 443 |
 | **use_ssl** | If true, the agent initializes a secure connection to Datadog. Ensure to update the port if you disable it. | true |
 | **max_retries** | The number of retries before the output plugin stops | 5 |


### PR DESCRIPTION
### What does this PR do?

Fixes the default value for the `host` parameter from `intake.logs.datadoghq.com` to `http-intake.logs.datadoghq.com` in the README.

### Motivation

The default http logs intake [in the code](https://github.com/DataDog/logstash-output-datadog_logs/blob/fd7c3b71e061475cb99d61d2c73b8a2e3c61a596/lib/logstash/outputs/datadog_logs.rb#L30
) is `http-intake.logs.datadoghq.com`.

### Additional Notes

Anything else we should know when reviewing?
