### PR TITLE
Fix `no_ssl_validation`

### DIFF
--- a/lib/logstash/outputs/datadog_logs.rb
+++ b/lib/logstash/outputs/datadog_logs.rb
@@ -246,6 +246,7 @@ class LogStash::Outputs::DatadogLogs < LogStash::Outputs::Base
       logger.info("Starting HTTP connection to #{protocol}://#{host}:#{port.to_s} with compression " + (use_compression ? "enabled" : "disabled") + (force_v1_routes ? " using v1 routes" : " using v2 routes"))
 
       config = {}
+      config[:ssl] = {}
       config[:ssl][:verify] = :disable if no_ssl_validation
       if http_proxy != ""
         config[:proxy] = http_proxy


### PR DESCRIPTION
### What does this PR do?

When configuring `no_ssl_validation`, the `:ssl` key was not set causing this to crash. 
This PR ensures the `:ssl` key is set. 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
