### PR TITLE
[AGNTLOG-325] README: claim Logstash 9.x compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ DatadogLogs lets you send logs to Datadog based on LogStash events.
 
 ## Requirements
 
-The plugin relies upon the `zlib` library for compressing data. Successfully tested with Logstash 6.x, 7.x and 8.x.
+The plugin relies upon the `zlib` library for compressing data. Successfully tested with Logstash 7.x, 8.x and 9.x.
 
 ## How to install it?
 


### PR DESCRIPTION
## Summary

Updates the [README Requirements line](https://github.com/DataDog/logstash-output-datadog_logs/blob/master/README.md#requirements) from "Successfully tested with Logstash 6.x, 7.x and 8.x" to "Successfully tested with Logstash 7.x, 8.x and 9.x" — matching what the CI matrix actually verifies.

## Why

Closes [AGNTLOG-325](https://datadoghq.atlassian.net/browse/AGNTLOG-325) — a customer asked whether Logstash 9.x is supported for log shipping, after seeing the public docs at https://docs.datadoghq.com/integrations/logstash/#log-collection citing older versions only.

## What CI already verifies

`.github/workflows/unittests.yml` `test-logstash-tests` matrix currently runs against:

- Logstash 7.17.8
- Logstash 8.6.1
- Logstash 9.2.2

All three jobs are green on master, so this PR is a pure-doc correction — no code or CI changes.

Logstash 6.x was dropped from the matrix at some point and the README still claimed it; this PR aligns the README with reality.

## Manual QA

No QA needed — README-only change.