### PR TITLE
Add Trusted Publishing workflow for RubyGems releases

### DIFF
--- a/.github/chainguard/self.publish.sts.yaml
+++ b/.github/chainguard/self.publish.sts.yaml
@@ -1,0 +1,13 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/logstash-output-datadog_logs:environment:rubygems.org
+
+claim_pattern:
+  event_name: workflow_dispatch
+  environment: rubygems.org
+  ref: refs/heads/master
+  repository: DataDog/logstash-output-datadog_logs
+  job_workflow_ref: DataDog/logstash-output-datadog_logs/\.github/workflows/publish\.yml@refs/heads/master
+
+permissions:
+  contents: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
         with:
           ruby-version: "3.3"
@@ -44,6 +46,14 @@ jobs:
           gem build logstash-output-datadog_logs.gemspec
           echo "::notice::Dry run complete. Gem built successfully: logstash-output-datadog_logs-${GEM_VERSION}.gem"
 
+      - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        if: ${{ inputs.push }}
+        id: octo-sts
+        with:
+          scope: DataDog/logstash-output-datadog_logs
+          policy: self.publish
       - name: Publish to RubyGems.org
         if: ${{ inputs.push }}
         uses: rubygems/release-gem@052cc82692552de3ef2b81fd670e41d13cba8092 # v1.4.0
+        with:
+          token: ${{ steps.octo-sts.outputs.token }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,49 @@
+name: Publish gem
+
+on:
+  workflow_dispatch:
+    inputs:
+      push:
+        description: "Push gem to RubyGems.org (false = dry run, true = publish)"
+        type: boolean
+        default: false
+        required: false
+
+concurrency: "rubygems"
+
+permissions: {}
+
+jobs:
+  publish:
+    name: Build and publish gem to RubyGems.org
+    runs-on: ubuntu-24.04
+    environment: ${{ inputs.push && 'rubygems.org' || '' }}
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
+        with:
+          ruby-version: "3.3"
+
+      - name: Verify gem version is not already published
+        run: |
+          GEM_VERSION=$(ruby -e "puts Gem::Specification.load('logstash-output-datadog_logs.gemspec').version")
+          echo "GEM_VERSION=${GEM_VERSION}" >> "$GITHUB_ENV"
+
+          if gem search logstash-output-datadog_logs --exact --remote --version "${GEM_VERSION}" | grep -q "(${GEM_VERSION})"; then
+            echo "::error::Version ${GEM_VERSION} is already published on RubyGems.org"
+            exit 1
+          fi
+          echo "Version ${GEM_VERSION} is ready to publish"
+
+      - name: Build gem (dry run)
+        if: ${{ !inputs.push }}
+        run: |
+          gem build logstash-output-datadog_logs.gemspec
+          echo "::notice::Dry run complete. Gem built successfully: logstash-output-datadog_logs-${GEM_VERSION}.gem"
+
+      - name: Publish to RubyGems.org
+        if: ${{ inputs.push }}
+        uses: rubygems/release-gem@052cc82692552de3ef2b81fd670e41d13cba8092 # v1.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+ - Switch to GitHub Actions Trusted Publishing for gem releases (replaces manual API key publishing) [#64](https://github.com/DataDog/logstash-output-datadog_logs/pull/64)
+
 ## 0.5.4
  - Fix issue where setting `no_ssl_validation` prevented the plugin from starting.
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,20 @@ filter {
 }
 ```
 
+## Releasing
+
+This gem is published to RubyGems via a GitHub Actions [Trusted Publishing](https://guides.rubygems.org/trusted-publishing/) workflow. No API keys or local credentials are needed.
+
+To release a new version:
+
+1. Update the version in `lib/logstash/outputs/version.rb`
+2. Update `CHANGELOG.md`
+3. Merge to `master`
+4. Go to **Actions** > **Publish gem** > **Run workflow**
+5. Run with `push` unchecked first (dry run) to verify the build
+6. Run again with `push` checked to publish to RubyGems
+7. The `rubygems.org` environment gate will ask for approval before publishing
+
 ## Need Help?
 
 If you need any support please contact us at support@datadoghq.com.


### PR DESCRIPTION
### What does this PR do?

Replace the static rubygems.org API key with a GitHub Actions OIDC-based Trusted Publishing workflow.

### Motivation
SDLC Security review

### Additional Notes
Part of the SDLC Security audit: https://datadoghq.atlassian.net/wiki/spaces/~776423855/pages/6936626815/Ruby+Package+Publishing
