### PR TITLE
Fix integration test grep for updated Datadog intake 403 response

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -111,4 +111,4 @@ jobs:
             # Match either "API key is invalid" or "API key is missing" — Datadog
             # intake wording has varied over time; the assertion we actually care
             # about is that the plugin reached intake and got a 403.
-            grep -qE 'datadoglogs - Unable to send payload due to client error: 403 .*"detail":"API key is (invalid|missing)"' /tmp/logstash.log
+            grep -qE 'datadoglogs - Unable to send payload due to client error: 403 .*API key is (invalid|missing)' /tmp/logstash.log


### PR DESCRIPTION


### What does this PR do?
Intake endpoint changed its 403 error response format from 
```
{"detail":"API key is invalid"}
```

to 

```
{"errors":[..."API key is missing or invalid"]}
```

Adjust the flaky test so our test would grep the correct content

### Motivation
https://github.com/DataDog/logs-backend/pull/107108


### Additional Notes